### PR TITLE
Add option to path follower to enforce base_link approximately equals frc_robot

### DIFF
--- a/zebROS_ws/src/auto_node/src/FourCoral.py
+++ b/zebROS_ws/src/auto_node/src/FourCoral.py
@@ -31,7 +31,7 @@ class FourCoral(AutoBase):
         
         return SeriesAction([
             ParallelAction([
-                drive_traj_iter.get_next_trajectory_action(dont_go_to_start=True),
+                drive_traj_iter.get_next_trajectory_action(dont_go_to_start=True, enforce_actually_localized=True),
                 SeriesAction([WaitTrajectoryAction(self.ELEVATOR_PERCENT_START),
                               PlacingAction(True)
                               ])
@@ -42,7 +42,7 @@ class FourCoral(AutoBase):
             WaitForIntakeAction(),
 
             ParallelAction([
-                drive_traj_iter.get_next_trajectory_action(dont_go_to_start=True),
+                drive_traj_iter.get_next_trajectory_action(dont_go_to_start=True, enforce_actually_localized=True),
                 SeriesAction([WaitTrajectoryAction(self.ELEVATOR_PERCENT),
                               PlacingAction(True)
                               ])
@@ -53,7 +53,7 @@ class FourCoral(AutoBase):
             WaitForIntakeAction(),
 
             ParallelAction([
-                drive_traj_iter.get_next_trajectory_action(),
+                drive_traj_iter.get_next_trajectory_action(dont_go_to_start=True, enforce_actually_localized=True),
                 SeriesAction([WaitTrajectoryAction(self.ELEVATOR_PERCENT),
                               PlacingAction(True)
                               ])
@@ -64,7 +64,7 @@ class FourCoral(AutoBase):
             WaitForIntakeAction(),
 
             ParallelAction([
-                drive_traj_iter.get_next_trajectory_action(),
+                drive_traj_iter.get_next_trajectory_action(dont_go_to_start=True, enforce_actually_localized=True),
                 SeriesAction([WaitTrajectoryAction(self.ELEVATOR_PERCENT),
                               PlacingAction(True)
                               ])

--- a/zebROS_ws/src/auto_node/src/drive_trajectory_iterator.py
+++ b/zebROS_ws/src/auto_node/src/drive_trajectory_iterator.py
@@ -29,7 +29,7 @@ class DriveTrajectoryActionIterator():
         self.__current_path = path_array
 
 
-    def get_next_trajectory_action(self, dont_go_to_start: bool = False, final_pos_tol: float = None, final_rot_tol: float = None) -> DriveTrajectoryAction:
+    def get_next_trajectory_action(self, dont_go_to_start: bool = False, enforce_actually_localized: bool = False, final_pos_tol: float = None, final_rot_tol: float = None) -> DriveTrajectoryAction:
         curr_iterator = self.__trajectory_index_iterator
         self.__trajectory_index_iterator = self.__trajectory_index_iterator + 1
 
@@ -37,7 +37,7 @@ class DriveTrajectoryActionIterator():
         #     rospy.logerr(f"Index out of range for trajectory {curr_iterator} in auto {self.__autonomous_name}")
         #     return None
         
-        return DriveTrajectoryAction(self.__autonomous_name, curr_iterator, self.__expected_trajectory_count, dont_go_to_start, final_pos_tol, final_rot_tol)
+        return DriveTrajectoryAction(self.__autonomous_name, curr_iterator, self.__expected_trajectory_count, dont_go_to_start=dont_go_to_start, enforce_actually_localized=enforce_actually_localized, final_pos_tol=final_pos_tol, final_rot_tol=final_rot_tol)
     
     def reset_iterator(self):
         self.__trajectory_index_iterator = 0

--- a/zebROS_ws/src/behaviors/src/2025_align_to_reef_tagslam.py
+++ b/zebROS_ws/src/behaviors/src/2025_align_to_reef_tagslam.py
@@ -190,7 +190,7 @@ class Aligner:
         path_goal.velocity_waypoints.poses.append(d)
         path_goal.velocity_waypoints.poses.append(d)
 
-        path_goal.wait_at_last_endpoint = True
+        path_goal.enforce_actually_localized = True
         rospy.loginfo(f"Sending path goal {path_goal}")
         self.path_client.send_goal(path_goal, done_cb=done_callback, feedback_cb=feedback_callback)
 

--- a/zebROS_ws/src/controller_node/launch/stage_sim.launch
+++ b/zebROS_ws/src/controller_node/launch/stage_sim.launch
@@ -63,4 +63,5 @@
     <node pkg="tf2_ros" type="static_transform_publisher" name="static_basefootprintlink" args="0 0 0 0 0 0 base_footprint base_link" />
     <!-- Stage odom is based at map origin, so create an identity transform here so map and odom are part of the same tree -->
     <node pkg="tf2_ros" type="static_transform_publisher" name="static_maptoodom" args="0 0 0 0 0 0 map odom" />
+    <node pkg="tf2_ros" type="static_transform_publisher" name="static_baselinktofrcrobot" args="0 0 0 0 0 0 base_link frc_robot" />
 </launch>

--- a/zebROS_ws/src/imu_zero/src/imu_zero.cpp
+++ b/zebROS_ws/src/imu_zero/src/imu_zero.cpp
@@ -142,7 +142,7 @@ void matchDataCallback(const frc_msgs::MatchSpecificData::ConstPtr& msg) {
   robot_enabled = robot_enabled || (msg->Enabled);
 }
 
-bool tagslam_zeroing_enabled = true;
+bool tagslam_zeroing_enabled = false;
 
 void tagslamCallback(const nav_msgs::Odometry::ConstPtr& msg) {
   // TODO: do we want to confirm multiple tag detections were used to create this estimate?

--- a/zebROS_ws/src/path_follower/config/path_follower_config.yaml
+++ b/zebROS_ws/src/path_follower/config/path_follower_config.yaml
@@ -13,6 +13,7 @@ path_follower:
     dynamic_reconfigure: True
     final_pos_tol: 0.0254 # was 8cm
     final_rot_tol: 0.034 # was 0.2 ~1deg = 0.017
+    max_baselink_to_tagslam_difference: 0.05 # seemed to be an okay value when looking at bags
     ros_rate: 250
     server_timeout: 15
     time_offset: 0.0

--- a/zebROS_ws/src/path_follower_msgs/action/Path.action
+++ b/zebROS_ws/src/path_follower_msgs/action/Path.action
@@ -13,6 +13,7 @@ float64 final_angvel_tol
 
 bool dont_go_to_start
 bool wait_at_last_endpoint # if true, will wait (and keep correcting error) at last endpoint until timeout
+bool enforce_actually_localized # if true, will wait for difference between frc_robot (tagslam frame) and base_link to be less than some param-configurable value
 ---
 bool timed_out
 bool success
@@ -24,3 +25,4 @@ int32 current_waypoint
 float64 x_error
 float64 y_error
 float64 angle_error
+float64 baselink_vs_tagslam_difference

--- a/zebROS_ws/src/teleop_joystick_control/src/teleop_joystick_comp_2025.cpp
+++ b/zebROS_ws/src/teleop_joystick_control/src/teleop_joystick_comp_2025.cpp
@@ -597,9 +597,9 @@ void buttonBoxCallback(const frc_msgs::ButtonBoxState2025ConstPtr &button_box)
 		}
 		ROS_INFO_STREAM("teleop_joystick_comp_2025 : zeroing IMU to " << imu_cmd.request.angle);
 		IMUZeroSrv.call(imu_cmd);
-		ROS_INFO_STREAM("teleop_joystick_comp_2025 : zeroing swerve odom");
-		std_srvs::Empty odom_cmd;
-		SwerveOdomZeroSrv.call(odom_cmd);
+		// ROS_INFO_STREAM("teleop_joystick_comp_2025 : zeroing swerve odom");
+		// std_srvs::Empty odom_cmd;
+		// SwerveOdomZeroSrv.call(odom_cmd);
 	}
 	if(button_box->zeroRelease) {
 	}


### PR DESCRIPTION
Current default tolerance: 0.05 m distance
This effectively makes sure that we haven't moved since TagSLAM's latest position update (which is probably behind)
Hopefully increases coral accuracy